### PR TITLE
Fix incompatibility with Twig v1.33.2

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -72,10 +72,7 @@ class Generator
      */
     function run()
     {
-        $loader = new Twig_Loader_Filesystem($this->templateDir, [
-            'cache' => false,
-            'debug' => true,
-        ]);
+        $loader = new Twig_Loader_Filesystem($this->templateDir);
 
         $twig = new Twig_Environment($loader);
 


### PR DESCRIPTION
Instantiation of Twig_Loader_Filesystem was failing on second parameter, which is expected to be a string variable representing file path common to path passed in first parameter, not a setting array as is passed in current version of this class in master.  I did not check impact on other areas of code (i.e. impact of removing cache/debug settings), but simply removing this parameter allow markdown generation to work in my environment.